### PR TITLE
[engine] [compile] update unit tests

### DIFF
--- a/operator_test.go
+++ b/operator_test.go
@@ -1144,16 +1144,18 @@ func TestBuiltinOperators(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		fn := builtinOperators[c.op]
-		assertNotNil(t, fn, c)
+		t.Run(c.op, func(t *testing.T) {
+			fn := builtinOperators[c.op]
+			assertNotNil(t, fn, c)
 
-		res, err := fn(nil, c.params)
-		if len(c.errMsg) != 0 {
-			assertErrStrContains(t, err, c.errMsg, c)
-			continue
-		}
+			res, err := fn(nil, c.params)
+			if len(c.errMsg) != 0 {
+				assertErrStrContains(t, err, c.errMsg, c)
+				return
+			}
 
-		assertNil(t, err, c)
-		assertEquals(t, res, c.res, c)
+			assertNil(t, err, c)
+			assertEquals(t, res, c.res, c)
+		})
 	}
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -439,23 +439,26 @@ func TestLex(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		p := &parser{source: c.expr}
-		err := p.lex()
-		if len(c.errMsg) != 0 {
-			assertErrStrContains(t, err, c.errMsg, c)
-			continue
-		}
 
-		assertNil(t, err, c)
+		t.Run(c.expr, func(t *testing.T) {
+			p := &parser{source: c.expr}
+			err := p.lex()
+			if len(c.errMsg) != 0 {
+				assertErrStrContains(t, err, c.errMsg, c)
+				return
+			}
 
-		assertEquals(t, len(p.tokens), len(c.tokens))
+			assertNil(t, err, c)
 
-		for i := range p.tokens {
-			t1 := p.tokens[i]
-			t2 := c.tokens[i]
-			assertEquals(t, t1.typ, t2.typ)
-			assertEquals(t, t1.val, t2.val)
-		}
+			assertEquals(t, len(p.tokens), len(c.tokens))
+
+			for i := range p.tokens {
+				t1 := p.tokens[i]
+				t2 := c.tokens[i]
+				assertEquals(t, t1.typ, t2.typ)
+				assertEquals(t, t1.val, t2.val)
+			}
+		})
 	}
 }
 
@@ -543,22 +546,24 @@ func TestParseConfig(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		p := newParser(&CompileConfig{CompileOptions: c.origin}, c.expr)
-		err := p.lex()
-		assertNil(t, err, c)
-		err = p.parseConfig()
-		if len(c.errMsg) != 0 {
-			assertErrStrContains(t, err, c.errMsg, c)
-			continue
-		}
-		assertNil(t, err, c)
-		updatedOption := p.conf.CompileOptions
+		t.Run(c.expr, func(t *testing.T) {
+			p := newParser(&CompileConfig{CompileOptions: c.origin}, c.expr)
+			err := p.lex()
+			assertNil(t, err, c)
+			err = p.parseConfig()
+			if len(c.errMsg) != 0 {
+				assertErrStrContains(t, err, c.errMsg, c)
+				return
+			}
+			assertNil(t, err, c)
+			updatedOption := p.conf.CompileOptions
 
-		for option, want := range c.want {
-			got, exist := updatedOption[option]
-			assertEquals(t, exist, true)
-			assertEquals(t, got, want)
-		}
+			for option, want := range c.want {
+				got, exist := updatedOption[option]
+				assertEquals(t, exist, true)
+				assertEquals(t, got, want)
+			}
+		})
 	}
 }
 
@@ -861,13 +866,15 @@ func TestParseAstTree(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		ast, _, err := newParser(c.cc, c.expr).parse()
-		if len(c.errMsg) != 0 {
-			assertErrStrContains(t, err, c.errMsg, c)
-			continue
-		}
+		t.Run(c.expr, func(t *testing.T) {
+			ast, _, err := newParser(c.cc, c.expr).parse()
+			if len(c.errMsg) != 0 {
+				assertErrStrContains(t, err, c.errMsg, c)
+				return
+			}
 
-		assertNil(t, err)
-		assertAstTreeIdentical(t, ast, c.ast, c)
+			assertNil(t, err)
+			assertAstTreeIdentical(t, ast, c.ast, c)
+		})
 	}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -56,7 +56,53 @@ func TestIndentByParentheses(t *testing.T) {
 `
 
 	res := IndentByParentheses(s)
-	fmt.Println(res)
+	assertEquals(t, res, `;;;; optimize:false
+;;;; hhhh
+(or ;; test
+  (eq
+    (= 1 1)
+    (= 1 2)
+    (eq
+      (= 1 1)
+      (= 1 2)
+      (= 1 1)
+      (= 1 1)))
+  (and
+    ;; hhhhh3
+    (between age 18 80)
+    (eq
+      (+ 1 1)
+      (- 3 1) 2)
+    (eq gender "male") ;; heheda
+    (between ;;hhhh4
+      (t_version app_version)
+      ( t_version "1.2.3")
+      (t_version "4.5")))
+  (=
+    (now) 123)
+  (in ""
+    ())
+  (=
+    (now) 123)
+  (now)
+  (overlap
+    ()
+    (1 2 3))
+  (overlap
+    ("a")
+    (""))
+  ;; hhhh5
+  (overlap groups
+    (1234 7680)) ;; todo remove extra space
+  ( ;; hehehe
+    overlap
+    ;; heheh6
+    ;; hhh 7
+    tags
+    ( "bbb" "aaa")) ;; todo remove extra space
+  ;; hhhh8
+) ;; hhh9
+;; hhh0`)
 }
 
 func TestPrintCode(t *testing.T) {
@@ -312,7 +358,9 @@ func TestGenerateTestCase(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		got := GenerateTestCase(c.expr, c.vals)
-		assertEquals(t, got, c.want)
+		t.Run(c.expr.Expr, func(t *testing.T) {
+			got := GenerateTestCase(c.expr, c.vals)
+			assertEquals(t, got, c.want)
+		})
 	}
 }


### PR DESCRIPTION
## Summary
this PR updates unit tests to use [t.Run()](https://pkg.go.dev/testing#T.Run) to execute subtests.

## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/larry618/eval	2.209s

```

- [X] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/larry618/eval_lab/benchmark/local
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	40507515	        79.47 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	44291850	        78.80 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	43747821	        79.56 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	43300621	        79.98 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/larry618/eval_lab/benchmark/local	14.550s
```

- [x] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     37668|     30000|      5247|        21|    2.109s|
|       2 %|       2 %|     67890|     60000|      5208|       282|    3.786s|
|       3 %|       3 %|     96243|     90000|      3681|       162|      4.2s|
|       4 %|       4 %|    122890|    120000|       210|       280|    4.089s|
|       5 %|       5 %|    152715|    150000|       314|         1|    4.034s|
|       6 %|       6 %|    185811|    180000|      3182|       229|    2.323s|
|       7 %|       7 %|    212819|    210000|       390|        29|    3.923s|
|       8 %|       8 %|    243497|    240000|      1028|        69|    4.168s|
|       9 %|       9 %|    272565|    270000|       143|        22|     4.18s|
|      10 %|      10 %|    302446|    300000|        28|        18|    4.235s|
|      11 %|      11 %|    332939|    330000|       411|       128|    4.283s|
|      12 %|      12 %|    363980|    360000|      1492|        88|    4.319s|
|      13 %|      13 %|    393287|    390000|       731|       156|    4.411s|
|      14 %|      14 %|    422514|    420000|       114|         0|    4.433s|
|      15 %|      15 %|    452555|    450000|        77|        78|    4.364s|
|      16 %|      16 %|    482610|    480000|        95|       115|    4.435s|
|      17 %|      17 %|    512651|    510000|       157|        94|    4.423s|
|      18 %|      18 %|    542817|    540000|         0|       430|    4.424s|
|      19 %|      19 %|    575596|    570000|      2997|       199|    4.291s|
|      20 %|      20 %|    604495|    600000|      1961|       134|    4.354s|
|      21 %|      21 %|    632607|    630000|       111|        96|    4.233s|
|      22 %|      22 %|    662491|    660000|        57|        34|    4.442s|
|      23 %|      23 %|    692486|    690000|         0|        93|    4.761s|
|      24 %|      24 %|    723286|    720000|       664|       222|     5.02s|
|      25 %|      25 %|    752798|    750000|       397|         1|    4.934s|
|      26 %|      26 %|    789473|    780000|      6934|       139|    3.069s|
|      27 %|      27 %|    813160|    810000|       639|       121|    4.658s|
|      28 %|      28 %|    842797|    840000|       348|        49|    4.939s|
|      29 %|      29 %|    872537|    870000|        56|        81|    4.813s|
|      30 %|      30 %|    902585|    900000|       161|        24|    4.946s|
|      31 %|      31 %|    932399|    930000|         0|         1|    4.979s|
|      32 %|      32 %|    962806|    960000|       406|         0|    4.942s|
|      33 %|      33 %|    992616|    990000|        89|       127|    4.976s|
|      34 %|      34 %|   1022537|   1020000|        88|        49|    4.888s|
|      35 %|      35 %|   1052511|   1050000|       110|         1|    4.978s|
|      36 %|      36 %|   1082360|   1080000|         0|         0|    4.641s|
|      37 %|      37 %|   1112373|   1110000|         0|         2|    4.942s|
|      38 %|      38 %|   1142597|   1140000|       145|        52|    4.811s|
|      39 %|      39 %|   1173260|   1170000|       499|       361|    4.823s|
|      40 %|      40 %|   1202822|   1200000|       396|        26|    4.652s|
|      41 %|      41 %|   1232653|   1230000|       186|        67|    4.726s|
|      42 %|      42 %|   1263913|   1260000|      1365|       148|    5.045s|
|      43 %|      43 %|   1293880|   1290000|      1268|       212|    4.907s|
|      44 %|      44 %|   1322440|   1320000|        15|        25|    4.865s|
|      45 %|      45 %|   1352885|   1350000|       389|        96|    4.884s|
|      46 %|      46 %|   1382541|   1380000|        18|       123|    4.963s|
|      47 %|      47 %|   1412608|   1410000|        16|       192|     4.86s|
|      48 %|      48 %|   1444405|   1440000|      1969|        36|    5.038s|
|      49 %|      49 %|   1473023|   1470000|       601|        22|    4.997s|
|      50 %|      50 %|   1502536|   1500000|        46|        90|    4.865s|
|      51 %|      51 %|   1532475|   1530000|        74|         1|    4.913s|
|      52 %|      52 %|   1562405|   1560000|         0|         6|     4.96s|
|      53 %|      53 %|   1592435|   1590000|         0|        41|    4.849s|
|      54 %|      54 %|   1622546|   1620000|        78|        68|    5.041s|
|      55 %|      55 %|   1653915|   1650000|      1449|        66|    4.883s|
|      56 %|      56 %|   1682743|   1680000|       215|       128|    5.011s|
|      57 %|      57 %|   1712427|   1710000|         0|        30|    4.906s|
|      58 %|      58 %|   1742638|   1740000|        72|       166|    4.963s|
|      59 %|      59 %|   1772460|   1770000|        58|         2|    4.893s|
|      60 %|      60 %|   1802778|   1800000|       290|        88|    4.971s|
|      61 %|      61 %|   1832652|   1830000|       179|        73|    4.989s|
|      62 %|      62 %|   1862405|   1860000|         0|         7|    5.031s|
|      63 %|      63 %|   1892825|   1890000|       346|        79|    5.071s|
|      64 %|      64 %|   1923239|   1920000|       814|        25|    5.028s|
|      65 %|      65 %|   1953601|   1950000|       342|       859|    5.105s|
|      66 %|      66 %|   1982532|   1980000|       122|        11|    5.047s|
|      67 %|      67 %|   2012614|   2010000|       211|         3|    5.181s|
|      68 %|      68 %|   2042704|   2040000|       194|       110|    5.214s|
|      69 %|      69 %|   2072539|   2070000|        80|        59|    5.276s|
|      70 %|      70 %|   2102556|   2100000|       112|        44|    5.225s|
|      71 %|      71 %|   2132397|   2130000|         0|         0|    5.227s|
|      72 %|      72 %|   2162588|   2160000|         0|       192|    5.433s|
|      73 %|      73 %|   2192765|   2190000|       349|        16|    5.209s|
|      74 %|      74 %|   2222605|   2220000|       185|        20|    5.155s|
|      75 %|      75 %|   2252857|   2250000|       324|       133|    5.161s|
|      76 %|      76 %|   2282438|   2280000|        27|        11|    5.195s|
|      77 %|      77 %|   2312430|   2310000|         0|        31|    5.392s|
|      78 %|      78 %|   2342599|   2340000|        60|       139|    5.267s|
|      79 %|      79 %|   2373673|   2370000|      1143|       130|     5.06s|
|      80 %|      80 %|   2404016|   2400000|      1510|       106|    5.086s|
|      81 %|      81 %|   2432588|   2430000|        67|       121|    5.252s|
|      82 %|      82 %|   2462716|   2460000|       264|        52|    5.113s|
|      83 %|      83 %|   2493013|   2490000|       500|       113|    5.088s|
|      84 %|      84 %|   2522408|   2520000|         6|         2|    5.377s|
|      85 %|      85 %|   2552787|   2550000|       338|        49|    5.114s|
|      86 %|      86 %|   2582393|   2580000|         0|         0|    5.254s|
|      87 %|      87 %|   2612558|   2610000|       140|        18|    5.154s|
|      88 %|      88 %|   2642492|   2640000|        51|        41|    5.115s|
|      89 %|      89 %|   2672522|   2670000|        75|        47|    5.144s|
|      90 %|      90 %|   2702567|   2700000|       146|        21|    5.207s|
|      91 %|      91 %|   2732497|   2730000|        82|        15|    5.461s|
|      92 %|      92 %|   2762446|   2760000|        43|         3|    5.348s|
|      93 %|      93 %|   2792511|   2790000|        88|        23|    5.431s|
|      94 %|      94 %|   2822512|   2820000|       110|         2|    5.326s|
|      95 %|      95 %|   2852457|   2850000|        43|        14|     5.52s|
|      96 %|      96 %|   2882713|   2880000|       313|         0|    5.484s|
|      97 %|      97 %|   2912346|   2910000|         0|         0|    5.462s|
|      98 %|      98 %|   2943087|   2940000|       687|         0|    5.298s|
|      99 %|      99 %|   2972684|   2970000|        76|       208|     5.62s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|    5.636s|
PASS
ok  	github.com/larry618/eval	489.535s
```

## Reviewers
@larry618