### PR TITLE
[compile] refactor compile & update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/larry618/eval
+module github.com/lkxy/eval
 
 go 1.18


### PR DESCRIPTION
## Summary
This PR refactors compile and update the go.mod the new account name

## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/lkxy/eval	1.864
```

- [x] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/larry618/eval_lab/benchmark/local
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	40177918	        80.08 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	42780594	        79.26 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	42990542	        79.38 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	42426292	        79.54 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/larry618/eval_lab/benchmark/local	13.963s
```

- [X] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     41828|     30000|      9193|       235|    2.096s|
|       2 %|       2 %|     64490|     60000|      1963|       127|    3.353s|
|       3 %|       3 %|     92531|     90000|       100|        31|    3.839s|
|       4 %|       4 %|    122850|    120000|       332|       118|    4.101s|
|       5 %|       5 %|    152577|    150000|       162|        15|    3.977s|
|       6 %|       6 %|    182399|    180000|         0|         0|    4.118s|
|       7 %|       7 %|    212475|    210000|        60|        15|    4.105s|
|       8 %|       8 %|    242625|    240000|       160|        65|    4.167s|
|       9 %|       9 %|    272502|    270000|        90|        12|    4.212s|
|      10 %|      10 %|    302626|    300000|       217|         9|    4.168s|
|      11 %|      11 %|    332624|    330000|       195|        29|    4.316s|
|      12 %|      12 %|    362752|    360000|       308|        44|    4.558s|
|      13 %|      13 %|    392569|    390000|       157|        12|    4.552s|
|      14 %|      14 %|    422667|    420000|       267|         0|     4.58s|
|      15 %|      15 %|    452728|    450000|       114|       214|    4.401s|
|      16 %|      16 %|    482422|    480000|        22|         0|    4.299s|
|      17 %|      17 %|    512611|    510000|       207|         4|    4.426s|
|      18 %|      18 %|    542914|    540000|       459|        55|    4.393s|
|      19 %|      19 %|    573563|    570000|       408|       755|    4.477s|
|      20 %|      20 %|    602553|    600000|         0|       158|    4.193s|
|      21 %|      21 %|    632461|    630000|        31|        30|    4.222s|
|      22 %|      22 %|    663281|    660000|       791|        90|    4.355s|
|      23 %|      23 %|    692603|    690000|       118|        85|    4.358s|
|      24 %|      24 %|    722900|    720000|       417|        83|    4.283s|
|      25 %|      25 %|    752478|    750000|        44|        34|    4.369s|
|      26 %|      26 %|    782535|    780000|        51|        84|    4.146s|
|      27 %|      27 %|    812708|    810000|       194|       114|    4.281s|
|      28 %|      28 %|    842536|    840000|        50|        86|    4.415s|
|      29 %|      29 %|    872743|    870000|       257|        86|    4.589s|
|      30 %|      30 %|    902821|    900000|        68|       353|    4.979s|
|      31 %|      31 %|    935909|    930000|      3445|        64|    2.953s|
|      32 %|      32 %|    963508|    960000|      1104|         4|    4.754s|
|      33 %|      33 %|    992398|    990000|         0|         0|    4.664s|
|      34 %|      34 %|   1022577|   1020000|       102|        75|    4.702s|
|      35 %|      35 %|   1052756|   1050000|       254|       102|    4.822s|
|      36 %|      36 %|   1082471|   1080000|         0|        72|    4.651s|
|      37 %|      37 %|   1113363|   1110000|       896|        67|    4.838s|
|      38 %|      38 %|   1142625|   1140000|       115|       110|    4.498s|
|      39 %|      39 %|   1173346|   1170000|       945|         1|    4.617s|
|      40 %|      40 %|   1202770|   1200000|       112|       258|     4.52s|
|      41 %|      41 %|   1232673|   1230000|       216|        58|    4.418s|
|      42 %|      42 %|   1262506|   1260000|        63|        43|    4.499s|
|      43 %|      43 %|   1292456|   1290000|         8|        48|    4.628s|
|      44 %|      44 %|   1322395|   1320000|         0|        26|    4.807s|
|      45 %|      45 %|   1353333|   1350000|       904|        29|      4.6s|
|      46 %|      46 %|   1382432|   1380000|        26|         6|    4.648s|
|      47 %|      47 %|   1414074|   1410000|      1495|       179|    4.674s|
|      48 %|      48 %|   1442391|   1440000|         0|         0|    4.809s|
|      49 %|      49 %|   1472523|   1470000|        39|        84|    4.734s|
|      50 %|      50 %|   1502430|   1500000|        23|         7|    4.678s|
|      51 %|      51 %|   1532472|   1530000|         0|        82|    4.629s|
|      52 %|      52 %|   1562568|   1560000|        27|       141|    4.697s|
|      53 %|      53 %|   1593851|   1590000|      1428|        23|    4.621s|
|      54 %|      54 %|   1622877|   1620000|       472|         5|    4.561s|
|      55 %|      55 %|   1652462|   1650000|        38|        24|    4.524s|
|      56 %|      56 %|   1682691|   1680000|       185|       106|    4.699s|
|      57 %|      57 %|   1712574|   1710000|       153|        21|    4.631s|
|      58 %|      58 %|   1742414|   1740000|        13|         1|    4.692s|
|      59 %|      59 %|   1772674|   1770000|       131|       143|    4.659s|
|      60 %|      60 %|   1803053|   1800000|       651|         3|    4.682s|
|      61 %|      61 %|   1832569|   1830000|        89|        80|    4.668s|
|      62 %|      62 %|   1862577|   1860000|       140|        37|     4.73s|
|      63 %|      63 %|   1893103|   1890000|       601|       102|    4.813s|
|      64 %|      64 %|   1922707|   1920000|        64|       243|    4.647s|
|      65 %|      65 %|   1952711|   1950000|       144|       167|    4.928s|
|      66 %|      66 %|   1982547|   1980000|       138|         9|     4.66s|
|      67 %|      67 %|   2012558|   2010000|       109|        49|    4.819s|
|      68 %|      68 %|   2042509|   2040000|        59|        50|    4.829s|
|      69 %|      69 %|   2072741|   2070000|       215|       126|    4.797s|
|      70 %|      70 %|   2102397|   2100000|         0|         1|    4.693s|
|      71 %|      71 %|   2133551|   2130000|       895|       256|    4.773s|
|      72 %|      72 %|   2162505|   2160000|       105|         0|     4.67s|
|      73 %|      73 %|   2192490|   2190000|        57|        33|    4.735s|
|      74 %|      74 %|   2222380|   2220000|         0|         0|    4.786s|
|      75 %|      75 %|   2252751|   2250000|       339|        12|    4.698s|
|      76 %|      76 %|   2282397|   2280000|         0|         0|     4.71s|
|      77 %|      77 %|   2312706|   2310000|       298|         8|    4.638s|
|      78 %|      78 %|   2342636|   2340000|         0|       238|    4.573s|
|      79 %|      79 %|   2372544|   2370000|        56|        88|    4.812s|
|      80 %|      80 %|   2402538|   2400000|       103|        35|    4.861s|
|      81 %|      81 %|   2432858|   2430000|       392|        66|    4.806s|
|      82 %|      82 %|   2463432|   2460000|       826|       206|    4.774s|
|      83 %|      83 %|   2492442|   2490000|        24|        18|     4.87s|
|      84 %|      84 %|   2523775|   2520000|      1162|       213|    4.908s|
|      85 %|      85 %|   2552531|   2550000|        93|        38|     4.85s|
|      86 %|      86 %|   2582681|   2580000|       227|        54|    4.809s|
|      87 %|      87 %|   2614371|   2610000|      1963|         8|     4.79s|
|      88 %|      88 %|   2643426|   2640000|      1024|         2|    4.679s|
|      89 %|      89 %|   2672405|   2670000|         1|         4|    4.736s|
|      90 %|      90 %|   2702341|   2700000|         0|         0|    4.713s|
|      91 %|      91 %|   2734333|   2730000|      1921|        12|    4.757s|
|      92 %|      92 %|   2762766|   2760000|       284|        82|    4.905s|
|      93 %|      93 %|   2792725|   2790000|       285|        40|    4.908s|
|      94 %|      94 %|   2822547|   2820000|        57|        90|      4.8s|
|      95 %|      95 %|   2852554|   2850000|       102|        52|    4.888s|
|      96 %|      96 %|   2882755|   2880000|       129|       226|    4.898s|
|      97 %|      97 %|   2912872|   2910000|       149|       323|    5.144s|
|      98 %|      98 %|   2946939|   2940000|      4500|        39|     2.81s|
|      99 %|      99 %|   2972443|   2970000|         0|        46|    4.794s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|    5.138s|
PASS
ok  	github.com/lkxy/eval	460.621s
```

## Reviewers
@larry618